### PR TITLE
Speedup docker rebuild

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM mozilla/sbt:8u171_0.13.13 AS build
 WORKDIR '/usr/local/src/spark'
+COPY build.sbt .
+RUN sbt update
+
 COPY . .
 RUN sbt projectAssembly/assembly
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM mozilla/sbt:8u171_0.13.13 AS build
 WORKDIR '/usr/local/src/spark'
 COPY build.sbt .
+COPY project project/
 RUN sbt update
 
 COPY . .


### PR DESCRIPTION
Выделение кэша зависимостей `sbt` в отдельный слой должно
ускорить пересборку контейнера. Аналогичный метод используется
в контейнере [dotnetcore](https://docs.docker.com/samples/dotnetcore/).