### PR TITLE
Fix endless Kafka rebalance

### DIFF
--- a/src/main/scala/com/infocom/examples/spark/ClickHouseStreamReceiver.scala
+++ b/src/main/scala/com/infocom/examples/spark/ClickHouseStreamReceiver.scala
@@ -62,7 +62,7 @@ object StreamReceiver {
         "enable.auto.commit" -> (true: java.lang.Boolean),
         //"session.timeout.ms" -> "60000",
         "auto.offset.reset" -> "latest",
-        "group.id" -> s"$topic-groupid"
+        "groupIdPrefix" -> s"gnss-stream-receiver-$topic-"
       )
 
       val stream = KafkaUtils.createDirectStream[Null, Array[TDataPoint]](

--- a/src/main/scala/com/infocom/examples/spark/ClickHouseStreamReceiver.scala
+++ b/src/main/scala/com/infocom/examples/spark/ClickHouseStreamReceiver.scala
@@ -62,7 +62,7 @@ object StreamReceiver {
         "enable.auto.commit" -> (true: java.lang.Boolean),
         //"session.timeout.ms" -> "60000",
         "auto.offset.reset" -> "latest",
-        "groupIdPrefix" -> s"gnss-stream-receiver-$topic-"
+        "group.id" -> s"$topic-groupid"
       )
 
       val stream = KafkaUtils.createDirectStream[Null, Array[TDataPoint]](

--- a/src/main/scala/com/infocom/examples/spark/ClickHouseStreamReceiver.scala
+++ b/src/main/scala/com/infocom/examples/spark/ClickHouseStreamReceiver.scala
@@ -60,7 +60,7 @@ object StreamReceiver {
         "key.deserializer" -> classOf[NullDeserializer],
         "value.deserializer" -> classOf[AvroDataPointDeserializer[Array[TDataPoint]]],
         "value.deserializer.type" -> classTag[Array[TDataPoint]].runtimeClass,
-        "enable.auto.commit" -> (true: java.lang.Boolean),
+        "enable.auto.commit" -> (false: java.lang.Boolean),
         //"session.timeout.ms" -> "60000",
         "auto.offset.reset" -> "latest",
         "group.id" -> s"gnss-stream-receiver-${clientUID}-${topic}"

--- a/src/main/scala/com/infocom/examples/spark/ClickHouseStreamReceiver.scala
+++ b/src/main/scala/com/infocom/examples/spark/ClickHouseStreamReceiver.scala
@@ -33,6 +33,7 @@ object StreamReceiver {
     val kafkaServerAddress = args(0)
     val clickHouseServerAddress = args(1)
     val jdbcUri = s"jdbc:clickhouse://$clickHouseServerAddress"
+    val clientUID = s"${UUID.randomUUID}"
 
     @transient val jdbcProps = new Properties()
     jdbcProps.setProperty("isolationLevel", "NONE")
@@ -62,7 +63,7 @@ object StreamReceiver {
         "enable.auto.commit" -> (true: java.lang.Boolean),
         //"session.timeout.ms" -> "60000",
         "auto.offset.reset" -> "latest",
-        "group.id" -> s"spark-kafka-source-gnss-stream-receiver-${UUID.randomUUID}-${topic}"
+        "group.id" -> s"gnss-stream-receiver-${clientUID}-${topic}"
       )
 
       val stream = KafkaUtils.createDirectStream[Null, Array[TDataPoint]](

--- a/src/main/scala/com/infocom/examples/spark/ClickHouseStreamReceiver.scala
+++ b/src/main/scala/com/infocom/examples/spark/ClickHouseStreamReceiver.scala
@@ -1,6 +1,6 @@
 package com.infocom.examples.spark
 
-import java.util.Properties
+import java.util.{Properties, UUID}
 import com.infocom.examples.spark.data._
 import com.infocom.examples.spark.schema.ClickHouse._
 import com.infocom.examples.spark.serialization._
@@ -62,7 +62,7 @@ object StreamReceiver {
         "enable.auto.commit" -> (true: java.lang.Boolean),
         //"session.timeout.ms" -> "60000",
         "auto.offset.reset" -> "latest",
-        "group.id" -> s"$topic-groupid"
+        "group.id" -> s"spark-kafka-source-gnss-stream-receiver-${UUID.randomUUID}-${topic}"
       )
 
       val stream = KafkaUtils.createDirectStream[Null, Array[TDataPoint]](


### PR DESCRIPTION
Параллельная работа нескольких одинаковых стримеров в одной группе
привело к странной циклической перебалансировке Kafka.

Этот PR использует:
- [x] отключение *autocommit*
- [x] уникальные `group.id`
 
как рекомендуется в официальной документации:

- https://spark.apache.org/docs/2.2.1/structured-streaming-kafka-integration.html
- https://spark.apache.org/docs/2.2.1/streaming-kafka-0-10-integration.html