### PR TITLE
Refactor Functions.scala methods

### DIFF
--- a/src/main/scala/com/infocom/examples/spark/Functions.scala
+++ b/src/main/scala/com/infocom/examples/spark/Functions.scala
@@ -31,22 +31,26 @@ object Functions extends Serializable {
     (time: Long) => time
   }
 
-  def f(freq: String): UserDefinedFunction = udf {
-    (system: String, glofreq: Int) =>
-      freq match {
-        case "L1CA" => system match {
-          case "GLONASS" => 1602.0e6 + glofreq * 0.5625e6
-          case "GPS" => 1575.42e6
-          case _ => 0
-        }
-        case "L2CA" => 1246.0e6 + glofreq * 0.4375e6
-        case "L2C" => 1227.60e6
-        case "L2P" => system match {
-          case "GLONASS" => 1246.0e6 + glofreq * 0.4375e6
-          case "GPS" => 1227.60e6
-          case _ => 0
-        }
-        case "L5Q" => 1176.45e6
+  def f: UserDefinedFunction = udf {
+    (system: String, freq: String, glofreq: Int) =>
+      system match {
+        case "GLONASS" =>
+          freq match {
+            case "L1CA"       => 1602.0e6 + glofreq * 0.5625e6
+            case "L2CA"       => 1246.0e6 + glofreq * 0.4375e6
+            case "L2P"        => 1246.0e6 + glofreq * 0.4375e6
+            case _            => 0
+          }
+
+        case "GPS" =>
+          freq match {
+            case "L1CA"       => 1575.42e6
+            case "L2C"        => 1227.60e6
+            case "L2P"        => 1227.60e6
+            case "L5Q"        => 1176.45e6
+            case _            => 0
+          }
+
         case _ => 0
       }
   }

--- a/src/main/scala/com/infocom/examples/spark/Functions.scala
+++ b/src/main/scala/com/infocom/examples/spark/Functions.scala
@@ -41,7 +41,11 @@ object Functions extends Serializable {
         }
         case "L2CA" => 1246.0e6 + glofreq * 0.4375e6
         case "L2C" => 1227.60e6
-        case "L2P" => 1227.60e6
+        case "L2P" => system match {
+          case "GLONASS" => 1246.0e6 + glofreq * 0.4375e6
+          case "GPS" => 1227.60e6
+          case _ => 0
+        }
         case "L5Q" => 1176.45e6
         case _ => 0
       }

--- a/src/main/scala/com/infocom/examples/spark/Functions.scala
+++ b/src/main/scala/com/infocom/examples/spark/Functions.scala
@@ -51,6 +51,7 @@ object Functions extends Serializable {
       }
   }
 
+  @deprecated("Duplicates functionality of f()", "logserver-spark 0.2.0")
   def f1: UserDefinedFunction = udf {
     (system: String, glofreq: Int) =>
       system match {
@@ -60,6 +61,7 @@ object Functions extends Serializable {
       }
   }
 
+  @deprecated("Duplicates functionality of f()", "logserver-spark 0.2.0")
   def f2: UserDefinedFunction = udf {
     (system: String, glofreq: Int) =>
       system match {

--- a/src/main/scala/com/infocom/examples/spark/RangeCalculations.scala
+++ b/src/main/scala/com/infocom/examples/spark/RangeCalculations.scala
@@ -87,8 +87,8 @@ object RangeCalculations {
       .agg(avg(k($"adr1", $"adr2", $"f1", $"f2", $"psr1", $"psr2")).as("K"))
 
     val computed = range
-      .withColumn("f1", f1($"system", $"glofreq"))
-      .withColumn("f2", f2($"system", $"glofreq"))
+      .withColumn("f1", f($"system", $"freq", $"glofreq"))
+      .withColumn("f2", f($"system", $"freq", $"glofreq"))
       //.withColumn("K", lit(0))
       .join(Ks, "sat")
       .withColumn("min", min($"time".as[Long]).over(Window.partitionBy($"sat")))

--- a/src/main/scala/com/infocom/examples/spark/TecCalculation.scala
+++ b/src/main/scala/com/infocom/examples/spark/TecCalculation.scala
@@ -4,43 +4,14 @@ import java.util.Properties
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql._
+import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions._
 
 import scala.collection.mutable
 
+import Functions._
+
 object NtFunctions extends Serializable {
-  /**
-   * Скорость света
-   */
-  val C = 299792458.0
-
-  import org.apache.spark.sql.expressions.UserDefinedFunction
-
-  /**
-   * Частота волны для сигнала
-   */
-  def f(freq: String): UserDefinedFunction = udf {
-    (system: String, glofreq: Int) =>
-      freq match {
-        case "L1CA" => system match {
-          case "GLONASS" => 1602.0e6 + glofreq * 0.5625e6
-          case "GPS" => 1575.42e6
-          case _ => 0
-        }
-        case "L2CA" => 1246.0e6 + glofreq * 0.4375e6
-        case "L2C" => 1227.60e6
-        case "L2P" => system match {
-          case "GLONASS" => 1246.0e6 + glofreq * 0.4375e6
-          case "GPS" => 1227.60e6
-          case _ => 0
-        }
-        case "L5Q" => 1176.45e6
-        case _ => 0
-      }
-  }
-
-  def waveLength(f: Double): Double = C / f
-
   /**
    * ПЭС без поправок
    */
@@ -149,7 +120,7 @@ object SigNtFunctions extends Serializable {
    *
    */
   def sigPhi(sigNT: Double, f: Double): Double = {
-    10e16 * 80.8 * math.Pi * sigNT / (NtFunctions.C * f)
+    10e16 * 80.8 * math.Pi * sigNT / (C * f)
   }
 
   /**
@@ -324,8 +295,8 @@ object TecCalculation extends Serializable {
         """.stripMargin,
       jdbcProps
     )
-      .withColumn("f1", NtFunctions.f(f1Name)($"system", $"glofreq"))
-      .withColumn("f2", NtFunctions.f(f2Name)($"system", $"glofreq"))
+      .withColumn("f1", f(f1Name)($"system", $"glofreq"))
+      .withColumn("f2", f(f2Name)($"system", $"glofreq"))
 
     //range.show()
 

--- a/src/main/scala/com/infocom/examples/spark/TecCalculation.scala
+++ b/src/main/scala/com/infocom/examples/spark/TecCalculation.scala
@@ -274,6 +274,8 @@ object TecCalculation extends Serializable {
          |  anyIf(adr, freq = '$f2Name') AS adr2,
          |  anyIf(psr, freq = '$f1Name') AS psr1,
          |  anyIf(psr, freq = '$f2Name') AS psr2,
+         |  anyIf(freq, freq = '$f1Name') AS f1,
+         |  anyIf(freq, freq = '$f2Name') AS f2,
          |  any(system) AS system,
          |  any(glofreq) AS glofreq,
          |  '$sigcomb' AS sigcomb
@@ -295,8 +297,8 @@ object TecCalculation extends Serializable {
         """.stripMargin,
       jdbcProps
     )
-      .withColumn("f1", f(f1Name)($"system", $"glofreq"))
-      .withColumn("f2", f(f2Name)($"system", $"glofreq"))
+      .withColumn("f1", f($"system", $"f1", $"glofreq"))
+      .withColumn("f2", f($"system", $"f2", $"glofreq"))
 
     //range.show()
 


### PR DESCRIPTION
- Удалено дублирование методов, скопированных из `Functions.scala`
- Методы `f1()` и `f2()` считаются устаревшими, так как дублирование функционала может привести к путанице
- Метод `f()` переписан к нормальному виду. Пришлось изменить запрос (вероятно, это была оптимизация)

Надеюсь все это не понадобится в дальнейшем. 