### PR TITLE
[ENH] Update sbt for Metals LSP support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,10 @@
-# current sbt version conflicts with bloom and metals
+### Ammonite REPL ###
+.ammonite/
+
+### Bloop ###
 .bloop/
+
+### Metals LSP ###
+.metals/
 .project/metals.sbt
+metals.sbt

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,16 @@ project/plugins/project/
 .scala_dependencies
 .worksheet
 
+### Ammonite REPL ###
+.ammonite/
+
+### Bloop ###
+.bloop/
+
+### Metals LSP ###
+.metals/
+.project/metals.sbt
+metals.sbt
 
 ### SBT ###
 # Simple Build Tool

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mozilla/sbt:8u171_0.13.13 AS build
+FROM mozilla/sbt:8u292_1.5.7 AS build
 WORKDIR '/usr/local/src/spark'
 COPY build.sbt .
 COPY project project/

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ val assemblyName = "novatel-streaming-assembly"
 
 ThisBuild / scalaVersion := "2.11.12"
 
-// scalariformSettings
+scalariformAutoformat := false
 
 scalastyleFailOnError := true
 

--- a/build.sbt
+++ b/build.sbt
@@ -107,7 +107,7 @@ Test / parallelExecution := false
 lazy val root = (project in file(".")).
   configs(IntegrationTest).
   settings(Defaults.itSettings: _*).
-  enablePlugins(AutomateHeaderPlugin).
+  // enablePlugins(AutomateHeaderPlugin).
   enablePlugins(JavaAppPackaging).
   enablePlugins(AssemblyPlugin)
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-sbt.version=0.13.13
+sbt.version=1.5.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,20 +16,20 @@
 
 logLevel := Level.Warn
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.2.0")
 
-addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.0")
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.2")
 
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
 
-addSbtPlugin("org.wartremover" % "sbt-wartremover" % "1.2.1")
+addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.9")
 
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
 
-addSbtPlugin("de.heikoseeberger" % "sbt-header" % "1.6.0")
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.6.5")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.2.0-M8")
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.8.1")
 
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.1.0")
+addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.2.4")


### PR DESCRIPTION
Для корректной работы LSP Metals необходимо обновить `sbt` и его
зависимости до современных версий. Текущая версия `sbt` == `1.5.7`.

Обновление повлекло за собой дополнительные изменения:

- Некоторые Wart'ы уже успели устареть и даже быди удалены. На замену и
  предложены новые, согласно официальной документации
- Оператор `in` устарел в пользу оператора `/`
- Версия Scala обновлена 2.11.8 -> 2.11.12 из за `sbt-wartremover`