### PR TITLE
[hotfix] Cut off filter splashes

### DIFF
--- a/src/main/scala/com/infocom/examples/spark/TecCalculation.scala
+++ b/src/main/scala/com/infocom/examples/spark/TecCalculation.scala
@@ -271,6 +271,9 @@ object TecCalculation extends Serializable {
 
     // выкинуть все значения, которых нет в range
     DNTMap --= (DNTMap -- rangeList).keys
+    NTMap    --= (NTMap -- rangeList).keys
+    avgNTMap --= (avgNTMap -- rangeList).keys
+    delNTMap --= (delNTMap -- rangeList).keys
 
     range.collect().foreach(row => {
       val sat = row(0).toString


### PR DESCRIPTION
Временное решение проблемы всплесков на графиках среднего ПЭС и СКО ПЭС.
Всплески вызывают ложные срабатывания при автоматическом обнаружении МИО
(в планах) и неправильное автомасштабирование графиков.

Этот PR добавляет удаление первых нестабильных значения в пролёте спутника,
выдаваемых фильтрами.