### PR TITLE
Fix: use default value when `lseen` is `NULL`

### DIFF
--- a/src/main/scala/com/infocom/examples/spark/TecCalculation.scala
+++ b/src/main/scala/com/infocom/examples/spark/TecCalculation.scala
@@ -245,7 +245,7 @@ object TecCalculation extends Serializable {
          |select
          |  sat,
          |  freq,
-         |  max(time) as lseen
+         |  ifNull(max(time), $from) as lseen
          |from
          |  rawdata.range
          |where


### PR DESCRIPTION
Исправления для регрессии в fix-lapses (#9). `lseen`, вычисленный на пустом
запросе, равен `NULL`, что вызывает `NullPointerException` в среде выполнения,
из-за чего воркер падает и уходит в перезагрузку. Не критично, но неприятно.
Такое обычно возникает, когда GPS-приёмник ещё не запущен.

Теперь берётся начальное время в качестве значения по-умолчанию.