### PR TITLE
Fix: add lost S4 of Sigma_Phi

### DIFF
--- a/src/main/scala/com/infocom/examples/spark/TecCalculation.scala
+++ b/src/main/scala/com/infocom/examples/spark/TecCalculation.scala
@@ -300,7 +300,7 @@ object TecCalculation extends Serializable {
     })
 
     runJobXz1(spark, from, to)
-    runJobS4(spark, from, to)
+    runJobS4pwr(spark, from, to)
     //runJobCorrelation(spark, from, to)
 
     to
@@ -456,8 +456,14 @@ object TecCalculation extends Serializable {
     sigcomb
   }
 
-  def runJobS4(spark: SparkSession, from: Long, to: Long): Unit = {
-    println(s"S4")
+  /*
+   NOTE: S_4 is better to calculate according to the formula from Sigma_Phi in
+   order to avoid the influence of multipath propagation
+
+   May be *deprecated* in future.
+   */
+  def runJobS4pwr(spark: SparkSession, from: Long, to: Long): Unit = {
+    println(s"S_4 pwr")
 
     val sc = spark.sqlContext
 
@@ -483,7 +489,7 @@ object TecCalculation extends Serializable {
       jdbcProps
     )
 
-    //CREATE TABLE computed.s4 (
+    //CREATE TABLE computed.s4pwr (
     //  time UInt64,
     //  sat String,
     //  freq String,
@@ -495,7 +501,7 @@ object TecCalculation extends Serializable {
     result
       .withColumnRenamed("time1s", "time")
       .select("time", "sat", "freq", "s4")
-      .write.mode("append").jdbc(jdbcUri, "computed.s4", jdbcProps)
+      .write.mode("append").jdbc(jdbcUri, "computed.s4pwr", jdbcProps)
   }
 
   def runJobDerivatives(spark: SparkSession, from: Long, to: Long, sat: String, sigcomb: String): Unit = {


### PR DESCRIPTION
Этот PR добавляет забытый функционал для $S_4(\sigma_\varphi)$.
До текущего PR вычислялась $S_4(P)$, что бессмысленно.

**Breaking changes:**

- Для корректной работы требуется соответствующее изменение структуры таблицы
  `computed.s4`, т.к. эта $S_4$ вычисляется *для комбинации частот*.
- Данные $S_4(P)$ перенаправляются в `computed.s4pwr`. Это может измениться в будущем.