### PR TITLE
Fix: `sigPhi` 10e16 typo and `s4pwr`: replace `range.cno` -> `ismdetobs.power` 

### DIFF
--- a/src/main/scala/com/infocom/examples/spark/TecCalculation.scala
+++ b/src/main/scala/com/infocom/examples/spark/TecCalculation.scala
@@ -135,7 +135,7 @@ object SigNtFunctions extends Serializable {
    *
    */
   def sigPhi(sigNT: Double, f: Double): Double = {
-    10e16 * 80.8 * math.Pi * sigNT / (C * f)
+    1e16 * 80.8 * math.Pi * sigNT / (C * f)
   }
 
   /**

--- a/src/main/scala/com/infocom/examples/spark/TecCalculation.scala
+++ b/src/main/scala/com/infocom/examples/spark/TecCalculation.scala
@@ -476,9 +476,9 @@ object TecCalculation extends Serializable {
          |  toUInt64(floor(time/1000,0)*1000) as time1s,
          |  sat,
          |  freq,
-         |  sqrt((avg(pow(exp10(cno/10),2)) - pow(avg(exp10(cno/10)),2)) / pow(avg(exp10(cno/10)),2)) as S4
+         |  sqrt((avg(pow(power,2)) - pow(avg(power),2)) / pow(avg(power),2)) as S4
          |FROM
-         |  rawdata.range
+         |  rawdata.ismdetobs
          |WHERE
          |  d BETWEEN toDate($from/1000) AND toDate($to/1000) AND time BETWEEN $from AND $to
          |GROUP BY


### PR DESCRIPTION
**Изменения:**

- Исправлена опечатка в выражении $\sigma_{\varphi}$

  Опечатка в использовании экспоненциальной нотации. Лишний `0` давал
  10-кратное отклонение от показаний приёмника.
  
  ![изображение](https://user-images.githubusercontent.com/65488726/193438751-b5d66890-ae2f-4642-8e09-32a23477cd5f.png)

  ![изображение](https://user-images.githubusercontent.com/65488726/193438714-46e536b1-3faf-443f-aef0-b53eae7fc866.png)

- `runJobS4pwr` теперь использует `range.ismdetobs.power`

  $C/No$ не позволяет извлечь значение мощности сигнала, необходимое в
  оригинальном выражении $S_4$. `range.ismdetobs.power` гораздо ближе по
  смыслу и выдаёт более правдопобные графики.

  ![изображение](https://user-images.githubusercontent.com/65488726/193438863-70f46549-af26-4f0f-bfa5-a70adb312774.png)