### PR TITLE
fix: Missing L2P_codeless

### DIFF
--- a/src/main/scala/com/infocom/examples/spark/Functions.scala
+++ b/src/main/scala/com/infocom/examples/spark/Functions.scala
@@ -44,11 +44,12 @@ object Functions extends Serializable {
 
         case "GPS" =>
           freq match {
-            case "L1CA"       => 1575.42e6
-            case "L2C"        => 1227.60e6
-            case "L2P"        => 1227.60e6
-            case "L5Q"        => 1176.45e6
-            case _            => 0
+            case "L1CA"         => 1575.42e6
+            case "L2C"          => 1227.60e6
+            case "L2P"          => 1227.60e6
+            case "L2P_codeless" => 1227.60e6
+            case "L5Q"          => 1176.45e6
+            case _              => 0
           }
 
         case _ => 0


### PR DESCRIPTION
## Summary

Добавляет в расчеты поддерживаемую `NovAtelLogReader` частоту `L2P_codeless`,
используемую в GPS.

## Details

Ранее считалась за $0$, как неизвестная. Все неизвестных частоты принимаются за
$0$ в текущей реализации. Все комбинации с частотой `L2P_codeless` приводили к
обнулению $ПЭС$. Теперь все соответствующие показатели для комбинаций с этой
частотой рассчитываются корректно.